### PR TITLE
French Localization Fix for Choose Your Country

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
                           "Info.plist", 
                           "Bundle+Resources.swift"],
                 resources: [
-                    .process("Resources/PhoneNumberMetadata.json")
+                    .process("Resources")
                 ]),
         .testTarget(name: "PhoneNumberKitTests",
                     dependencies: ["PhoneNumberKit"],

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "PhoneNumberKit",
+    defaultLocalization: "en",
     platforms: [
         .iOS(.v9), .macOS(.v10_10), .tvOS(.v9), .watchOS(.v2)
     ],

--- a/PhoneNumberKit.xcodeproj/project.pbxproj
+++ b/PhoneNumberKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0F2FB36B26BDA3E2000EEE23 /* Localizable.strings in Sources */ = {isa = PBXBuildFile; fileRef = 0F64F15726BD93C200598B72 /* Localizable.strings */; };
 		0F64F15526BD93C200598B72 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0F64F15726BD93C200598B72 /* Localizable.strings */; };
 		11C2EF391D62BC3200052D44 /* NSRegularExpression+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C2EF381D62BC3200052D44 /* NSRegularExpression+Swift.swift */; };
 		1B0651171E2AD698006AE849 /* PhoneNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */; };
@@ -426,8 +427,8 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
-				Base,
 				"fr-CA",
+				Base,
 			);
 			mainGroup = 3424185A1BB6E5A000EE70E7;
 			productRefGroup = 342418651BB6E5A000EE70E7 /* Products */;
@@ -492,6 +493,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0F2FB36B26BDA3E2000EEE23 /* Localizable.strings in Sources */,
 				11C2EF391D62BC3200052D44 /* NSRegularExpression+Swift.swift in Sources */,
 				34F26FBE2517DCB700B6AF4D /* Bundle+Resources.swift in Sources */,
 				342418821BB70F5200EE70E7 /* PhoneNumberParser.swift in Sources */,

--- a/PhoneNumberKit.xcodeproj/project.pbxproj
+++ b/PhoneNumberKit.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0F64F14F26BD8B5E00598B72 /* MissingLocalizedStrings.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0F64F14E26BD8B5E00598B72 /* MissingLocalizedStrings.strings */; };
+		0F64F15526BD93C200598B72 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0F64F15726BD93C200598B72 /* Localizable.strings */; };
 		11C2EF391D62BC3200052D44 /* NSRegularExpression+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C2EF381D62BC3200052D44 /* NSRegularExpression+Swift.swift */; };
 		1B0651171E2AD698006AE849 /* PhoneNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */; };
 		1B1A4DD723007580006AE849 /* PhoneNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */; };
@@ -95,7 +95,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0F64F14E26BD8B5E00598B72 /* MissingLocalizedStrings.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = MissingLocalizedStrings.strings; sourceTree = "<group>"; };
+		0F64F15626BD93C200598B72 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		0F64F15826BD93DB00598B72 /* fr-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "fr-CA"; path = "fr-CA.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		11C2EF381D62BC3200052D44 /* NSRegularExpression+Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSRegularExpression+Swift.swift"; sourceTree = "<group>"; };
 		1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumberFormatter.swift; sourceTree = "<group>"; };
 		3417BD6A2210AC4900477EE7 /* MetadataParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataParsing.swift; sourceTree = "<group>"; };
@@ -254,7 +255,7 @@
 			isa = PBXGroup;
 			children = (
 				3435CC951BBFF66F003F953B /* PhoneNumberMetadata.json */,
-				0F64F14E26BD8B5E00598B72 /* MissingLocalizedStrings.strings */,
+				0F64F15726BD93C200598B72 /* Localizable.strings */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -426,6 +427,7 @@
 			knownRegions = (
 				en,
 				Base,
+				"fr-CA",
 			);
 			mainGroup = 3424185A1BB6E5A000EE70E7;
 			productRefGroup = 342418651BB6E5A000EE70E7 /* Products */;
@@ -446,8 +448,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0F64F14F26BD8B5E00598B72 /* MissingLocalizedStrings.strings in Resources */,
 				34CA34522380307300788D7D /* PhoneNumberMetadata.json in Resources */,
+				0F64F15526BD93C200598B72 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -592,6 +594,18 @@
 			targetProxy = 342418701BB6E5A000EE70E7 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		0F64F15726BD93C200598B72 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				0F64F15626BD93C200598B72 /* en */,
+				0F64F15826BD93DB00598B72 /* fr-CA */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		342418761BB6E5A000EE70E7 /* Debug */ = {

--- a/PhoneNumberKit.xcodeproj/project.pbxproj
+++ b/PhoneNumberKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0F64F14F26BD8B5E00598B72 /* MissingLocalizedStrings.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0F64F14E26BD8B5E00598B72 /* MissingLocalizedStrings.strings */; };
 		11C2EF391D62BC3200052D44 /* NSRegularExpression+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C2EF381D62BC3200052D44 /* NSRegularExpression+Swift.swift */; };
 		1B0651171E2AD698006AE849 /* PhoneNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */; };
 		1B1A4DD723007580006AE849 /* PhoneNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */; };
@@ -94,6 +95,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0F64F14E26BD8B5E00598B72 /* MissingLocalizedStrings.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = MissingLocalizedStrings.strings; sourceTree = "<group>"; };
 		11C2EF381D62BC3200052D44 /* NSRegularExpression+Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSRegularExpression+Swift.swift"; sourceTree = "<group>"; };
 		1B0651161E2AD698006AE849 /* PhoneNumberFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneNumberFormatter.swift; sourceTree = "<group>"; };
 		3417BD6A2210AC4900477EE7 /* MetadataParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataParsing.swift; sourceTree = "<group>"; };
@@ -252,6 +254,7 @@
 			isa = PBXGroup;
 			children = (
 				3435CC951BBFF66F003F953B /* PhoneNumberMetadata.json */,
+				0F64F14E26BD8B5E00598B72 /* MissingLocalizedStrings.strings */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -443,6 +446,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0F64F14F26BD8B5E00598B72 /* MissingLocalizedStrings.strings in Resources */,
 				34CA34522380307300788D7D /* PhoneNumberMetadata.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PhoneNumberKit/Resources/MissingLocalizedStrings.strings
+++ b/PhoneNumberKit/Resources/MissingLocalizedStrings.strings
@@ -1,0 +1,9 @@
+/* 
+  MissingLocalizedStrings.strings
+  PhoneNumberKit
+
+  Created by George Nyame on 2021-08-06.
+  Copyright © 2021 Roy Marmelstein. All rights reserved.
+*/
+
+"Choose your country" = "TEST TEST TEST"

--- a/PhoneNumberKit/Resources/en.lproj/Localizable.strings
+++ b/PhoneNumberKit/Resources/en.lproj/Localizable.strings
@@ -6,4 +6,4 @@
   Copyright © 2021 Roy Marmelstein. All rights reserved.
 */
 
-"Choose your country" = "TEST TEST TEST";
+"CHOOSE_YOUR_COUNTRY" = "TEST TEST TEST";

--- a/PhoneNumberKit/Resources/en.lproj/Localizable.strings
+++ b/PhoneNumberKit/Resources/en.lproj/Localizable.strings
@@ -6,4 +6,6 @@
   Copyright © 2021 Roy Marmelstein. All rights reserved.
 */
 
-"CHOOSE_YOUR_COUNTRY" = "TEST TEST TEST";
+"CHOOSE_YOUR_COUNTRY" = "Choose your country";
+"CURRENT" = "Current";
+"COMMON" = "Common";

--- a/PhoneNumberKit/Resources/en.lproj/Localizable.strings
+++ b/PhoneNumberKit/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+/* 
+  Localizable.strings
+  PhoneNumberKit
+
+  Created by George Nyame on 2021-08-06.
+  Copyright © 2021 Roy Marmelstein. All rights reserved.
+*/
+
+"Choose your country" = "TEST TEST TEST";

--- a/PhoneNumberKit/Resources/fr-CA.lproj/Localizable.strings
+++ b/PhoneNumberKit/Resources/fr-CA.lproj/Localizable.strings
@@ -1,9 +1,9 @@
 /* 
-  MissingLocalizedStrings.strings
+  Localizable.strings
   PhoneNumberKit
 
   Created by George Nyame on 2021-08-06.
   Copyright © 2021 Roy Marmelstein. All rights reserved.
 */
 
-"Choose your country" = "TEST TEST TEST"
+"Choose your country" = "This is Canadian French";

--- a/PhoneNumberKit/Resources/fr-CA.lproj/Localizable.strings
+++ b/PhoneNumberKit/Resources/fr-CA.lproj/Localizable.strings
@@ -6,4 +6,4 @@
   Copyright © 2021 Roy Marmelstein. All rights reserved.
 */
 
-"Choose your country" = "This is Canadian French";
+"CHOOSE_YOUR_COUNTRY" = "This is Canadian French";

--- a/PhoneNumberKit/Resources/fr-CA.lproj/Localizable.strings
+++ b/PhoneNumberKit/Resources/fr-CA.lproj/Localizable.strings
@@ -6,6 +6,6 @@
   Copyright © 2021 Roy Marmelstein. All rights reserved.
 */
 
-"CHOOSE_YOUR_COUNTRY" = "Choose your country (FRENCH NEEDED)";
-"CURRENT" = "Current (FRENCH NEEDED)";
-"COMMON" = "Common (FRENCH NEEDED)";
+"CHOOSE_YOUR_COUNTRY" = "Choisissez votre pays"
+"CURRENT" = "Actuel";
+"COMMON" = "Courant";

--- a/PhoneNumberKit/Resources/fr-CA.lproj/Localizable.strings
+++ b/PhoneNumberKit/Resources/fr-CA.lproj/Localizable.strings
@@ -6,4 +6,6 @@
   Copyright © 2021 Roy Marmelstein. All rights reserved.
 */
 
-"CHOOSE_YOUR_COUNTRY" = "This is Canadian French";
+"CHOOSE_YOUR_COUNTRY" = "Choose your country (FRENCH NEEDED)";
+"CURRENT" = "Current (FRENCH NEEDED)";
+"COMMON" = "Common (FRENCH NEEDED)";

--- a/PhoneNumberKit/Resources/fr-CA.lproj/Localizable.strings
+++ b/PhoneNumberKit/Resources/fr-CA.lproj/Localizable.strings
@@ -6,6 +6,6 @@
   Copyright © 2021 Roy Marmelstein. All rights reserved.
 */
 
-"CHOOSE_YOUR_COUNTRY" = "Choisissez votre pays"
+"CHOOSE_YOUR_COUNTRY" = "Choisissez votre pays";
 "CURRENT" = "Actuel";
 "COMMON" = "Courant";

--- a/PhoneNumberKit/UI/CountryCodePickerViewController.swift
+++ b/PhoneNumberKit/UI/CountryCodePickerViewController.swift
@@ -97,7 +97,7 @@ public class CountryCodePickerViewController: UITableViewController {
     func commonInit() {
 //        self.title = NSLocalizedString("PhoneNumberKit.CountryCodePicker.Title", value: "Choose your country", comment: "Title of CountryCodePicker ViewController")
         
-        self.title = NSLocalizedString("CHOOSE_YOUR_COUNTRY", comment: "Title of CountryCodePicker ViewController")
+        self.title = NSLocalizedString("CHOOSE_YOUR_COUNTRY", bundle: .module, comment: "Title of CountryCodePicker ViewController")
 
         tableView.register(Cell.self, forCellReuseIdentifier: Cell.reuseIdentifier)
         searchController.searchResultsUpdater = self

--- a/PhoneNumberKit/UI/CountryCodePickerViewController.swift
+++ b/PhoneNumberKit/UI/CountryCodePickerViewController.swift
@@ -95,7 +95,9 @@ public class CountryCodePickerViewController: UITableViewController {
     }
 
     func commonInit() {
-        self.title = NSLocalizedString("PhoneNumberKit.CountryCodePicker.Title", value: "Choose your country", comment: "Title of CountryCodePicker ViewController")
+//        self.title = NSLocalizedString("PhoneNumberKit.CountryCodePicker.Title", value: "Choose your country", comment: "Title of CountryCodePicker ViewController")
+        
+        self.title = NSLocalizedString("Choose your country", comment: "Title of CountryCodePicker ViewController")
 
         tableView.register(Cell.self, forCellReuseIdentifier: Cell.reuseIdentifier)
         searchController.searchResultsUpdater = self

--- a/PhoneNumberKit/UI/CountryCodePickerViewController.swift
+++ b/PhoneNumberKit/UI/CountryCodePickerViewController.swift
@@ -96,8 +96,8 @@ public class CountryCodePickerViewController: UITableViewController {
 
     func commonInit() {
 //        self.title = NSLocalizedString("PhoneNumberKit.CountryCodePicker.Title", value: "Choose your country", comment: "Title of CountryCodePicker ViewController")
-        
-        self.title = NSLocalizedString("CHOOSE_YOUR_COUNTRY", bundle: .module, comment: "Title of CountryCodePicker ViewController")
+        self.title = NSLocalizedString("PhoneNumberKit.CountryCodePicker.Title", bundle: .module, comment: "Title of CountryCodePicker ViewController")
+//        self.title = NSLocalizedString("CHOOSE_YOUR_COUNTRY", bundle: .module, comment: "Title of CountryCodePicker ViewController")
 
         tableView.register(Cell.self, forCellReuseIdentifier: Cell.reuseIdentifier)
         searchController.searchResultsUpdater = self

--- a/PhoneNumberKit/UI/CountryCodePickerViewController.swift
+++ b/PhoneNumberKit/UI/CountryCodePickerViewController.swift
@@ -97,7 +97,7 @@ public class CountryCodePickerViewController: UITableViewController {
     func commonInit() {
 //        self.title = NSLocalizedString("PhoneNumberKit.CountryCodePicker.Title", value: "Choose your country", comment: "Title of CountryCodePicker ViewController")
         
-        self.title = NSLocalizedString("Choose your country", comment: "Title of CountryCodePicker ViewController")
+        self.title = NSLocalizedString("CHOOSE_YOUR_COUNTRY", comment: "Title of CountryCodePicker ViewController")
 
         tableView.register(Cell.self, forCellReuseIdentifier: Cell.reuseIdentifier)
         searchController.searchResultsUpdater = self

--- a/PhoneNumberKit/UI/CountryCodePickerViewController.swift
+++ b/PhoneNumberKit/UI/CountryCodePickerViewController.swift
@@ -156,9 +156,9 @@ public class CountryCodePickerViewController: UITableViewController {
         } else if section == 0, hasCurrent {
             return NSLocalizedString("CURRENT", bundle: .module, comment: "Section Title of Current Section")
         } else if section == 0, !hasCurrent, hasCommon {
-            return NSLocalizedString("COMMON", bundle: .module, comment: "Section Title of Common Sections")
+            return NSLocalizedString("COMMON", bundle: .module, comment: "Section Title of Common Section")
         } else if section == 1, hasCurrent, hasCommon {
-            return NSLocalizedString("COMMON", bundle: .module, comment: "Section Title of Common Sections")
+            return NSLocalizedString("COMMON", bundle: .module, comment: "Section Title of Common Section")
         }
         return countries[section].first?.name.first.map(String.init)
     }

--- a/PhoneNumberKit/UI/CountryCodePickerViewController.swift
+++ b/PhoneNumberKit/UI/CountryCodePickerViewController.swift
@@ -95,9 +95,7 @@ public class CountryCodePickerViewController: UITableViewController {
     }
 
     func commonInit() {
-//        self.title = NSLocalizedString("PhoneNumberKit.CountryCodePicker.Title", value: "Choose your country", comment: "Title of CountryCodePicker ViewController")
-        self.title = NSLocalizedString("PhoneNumberKit.CountryCodePicker.Title", bundle: .module, comment: "Title of CountryCodePicker ViewController")
-//        self.title = NSLocalizedString("CHOOSE_YOUR_COUNTRY", bundle: .module, comment: "Title of CountryCodePicker ViewController")
+        self.title = NSLocalizedString("CHOOSE_YOUR_COUNTRY", bundle: .module, comment: "Title of CountryCodePicker ViewController")
 
         tableView.register(Cell.self, forCellReuseIdentifier: Cell.reuseIdentifier)
         searchController.searchResultsUpdater = self
@@ -156,11 +154,11 @@ public class CountryCodePickerViewController: UITableViewController {
         if isFiltering {
             return nil
         } else if section == 0, hasCurrent {
-            return NSLocalizedString("PhoneNumberKit.CountryCodePicker.Current", value: "Current", comment: "Name of \"Current\" section")
+            return NSLocalizedString("CURRENT", bundle: .module, comment: "Section Title of Current Section")
         } else if section == 0, !hasCurrent, hasCommon {
-            return NSLocalizedString("PhoneNumberKit.CountryCodePicker.Common", value: "Common", comment: "Name of \"Common\" section")
+            return NSLocalizedString("COMMON", bundle: .module, comment: "Section Title of Common Sections")
         } else if section == 1, hasCurrent, hasCommon {
-            return NSLocalizedString("PhoneNumberKit.CountryCodePicker.Common", value: "Common", comment: "Name of \"Common\" section")
+            return NSLocalizedString("COMMON", bundle: .module, comment: "Section Title of Common Sections")
         }
         return countries[section].first?.name.first.map(String.init)
     }


### PR DESCRIPTION
Localization fix for PhoneNumberKit's Choose your country page. This fix will cover English and French (Canada) languages.

~_Localizations for french still need_~

English | French (Canada)
------------ | -------------
<img src="https://user-images.githubusercontent.com/14320967/128555604-b7890358-be2f-405a-a38e-5ae678e7865c.png" width=300> | <img src="https://user-images.githubusercontent.com/14320967/128555678-b686f9bd-62d0-416c-8102-ab59132c8e2d.png" width=300>
